### PR TITLE
Add pkg-config and gettext as build dependencies.

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -8,6 +8,8 @@ class Neovim < Formula
   depends_on "libtool" => :build
   depends_on "automake" => :build
   depends_on "autoconf" => :build
+  depends_on "pkg-config" => :build
+  depends_on "gettext" => :build
 
   resource "libuv" do
     url "https://github.com/libuv/libuv/archive/v0.11.28.tar.gz"


### PR DESCRIPTION
gettext is not strictly required, but should be present for a proper
full build of Neovim.
