### PR TITLE
Add missing build dependency for pkg-config.

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -8,6 +8,7 @@ class Neovim < Formula
   depends_on "libtool" => :build
   depends_on "automake" => :build
   depends_on "autoconf" => :build
+  depends_on "pkg-config" => :build
 
   resource "libuv" do
     url "https://github.com/libuv/libuv/archive/v0.11.28.tar.gz"


### PR DESCRIPTION
The Homebrew build on OS-X Yosemite fails in libtickit because header files can't be found.  The header include paths are incomplete because pkg-config is not available in the build sandbox, so invocations of pkg-config to find the header files fail.
