### PR TITLE
Update sha1 for libtickit

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -43,7 +43,7 @@ class Neovim < Formula
 
   resource "libtickit" do
     url "https://github.com/neovim/libtickit/archive/neovim.tar.gz"
-    sha1 "08a2aa9ab4bacbeeafefac430691089d829fdb13"
+    sha1 "49e609de29c3bdc3b40d2ade76e69fde6e0d74bc"
   end
 
   def install


### PR DESCRIPTION
When installing with homebrew I had the following error:

```
==> Verifying neovim--libtickit-HEAD.tar.gz checksum
Error: SHA1 mismatch
Expected: 08a2aa9ab4bacbeeafefac430691089d829fdb13
Actual: 49e609de29c3bdc3b40d2ade76e69fde6e0d74bc
Archive: /Library/Caches/Homebrew/neovim--libtickit-HEAD.tar.gz
To retry an incomplete download, remove the file above.
```

This PR fixes it by changing the `sha1` to the correct value
