### PR TITLE
add depends_on :python for old version Mac

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -8,6 +8,7 @@ class Neovim < Formula
   depends_on "autoconf" => :build
   depends_on "pkg-config" => :build
   depends_on "gettext" => :build
+  depends_on :python => :recommended if MacOS.version <= :snow_leopard
 
   resource "libuv" do
     url "https://github.com/libuv/libuv/archive/v1.0.1.tar.gz"


### PR DESCRIPTION
For old version Mac, system python would be too old for neovim. Adding `depends_on :python` in such case.