### PR TITLE
Remove GIT_DIR hack

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -41,7 +41,6 @@ class Neovim < Formula
   end
 
   def install
-    ENV["GIT_DIR"] = cached_download/".git" if build.head?
     ENV.deparallelize
 
     resources.each do |r|


### PR DESCRIPTION
Homebrew has dropped the `git export` approach. Instead,
it copies the entire source dir to build dir. So the GIT_DIR
hack becomes obsolete.

Ref: https://github.com/Homebrew/homebrew/commit/359e972d4a75182ace2557e94d1a586ae66e7ad7