### PR TITLE
ci: audit formula after installed it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ install:
   - brew tap
   - export PATH="$PWD/bin:${PATH}"
 script:
-  - brew head-audit neovim --strict
   - brew install neovim --HEAD --verbose
+  - brew head-audit neovim --strict
   - brew test neovim
 matrix:
   fast_finish: true


### PR DESCRIPTION
There are post-install checks in `brew audit`.
So let's audit neovim after we installed it.