### PR TITLE
Simplify tap command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Homebrew formula for neovim.
 ## Usage
 
 ```bash
-$ brew tap neovim/homebrew-neovim
+$ brew tap neovim/neovim
 $ brew install --HEAD neovim
 ```
 


### PR DESCRIPTION
The `homebrew-` prefix is unnecessary when tapping.