### PR TITLE
set $HOME to buildpath

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -52,6 +52,7 @@ class Neovim < Formula
 
   def install
     ENV.deparallelize
+    ENV["HOME"] = buildpath
 
     resources.each do |r|
       r.stage(buildpath/".deps/build/src/#{r.name}")


### PR DESCRIPTION
During the installation, luarocks will write cache into $HOME path.
This is against Homebrew policy and can cause download trouble in rare
situtation. So let's set $HOME to buildpath.

Also for the heads up, in the future, Homebrew will build all formulae
inside an Apple Sandbox. Writing files outside prefix like this will
end up with building error.