### PR TITLE
formula to install neovim-dot-app

### DIFF
--- a/Formula/neovim-dot-app.rb
+++ b/Formula/neovim-dot-app.rb
@@ -1,0 +1,23 @@
+class NeovimDotApp < Formula
+  homepage "https://github.com/rogual/neovim-dot-app"
+  head "https://github.com/rogual/neovim-dot-app.git"
+
+  depends_on "scons"
+  depends_on "msgpack"
+  depends_on "neovim"
+
+  # scons requires python 2
+  depends_on "python"
+  depends_on :xcode
+  depends_on :arch => :x86_64
+
+  def install
+    ENV.prepend_path "PATH", Formula["python"].opt_bin
+    system "make", "NVIM=#{Formula["neovim"].opt_bin}/nvim"
+    prefix.install "build/Neovim.app"
+  end
+
+  test do
+    system "build/test"
+  end
+end


### PR DESCRIPTION
I have created a formula to install Neovim.app by @rogual - https://github.com/rogual/neovim-dot-app
I am not sure if it is not appropriate to put it here.

For those we are interested, for the moment, you can install Neovim.app by
```
brew install https://raw.githubusercontent.com/randy3k/homebrew-neovim/master/Formula/neovim-dot-app.rb --HEAD
```