### PR TITLE
[RFC] Disable Busted.

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -58,7 +58,11 @@ class Neovim < Formula
       r.stage(buildpath/".deps/build/src/#{r.name}")
     end
 
-    system "make", "CMAKE_BUILD_TYPE=RelWithDebInfo", "CMAKE_EXTRA_FLAGS=\"-DCMAKE_INSTALL_PREFIX:PATH=#{prefix}\"", "install"
+    system "make",
+           "CMAKE_BUILD_TYPE=RelWithDebInfo",
+           "DEPS_CMAKE_FLAGS=-DUSE_BUNDLED_BUSTED=OFF",
+           "CMAKE_EXTRA_FLAGS=\"-DCMAKE_INSTALL_PREFIX:PATH=#{prefix}\"",
+           "install"
   end
 
   def caveats; <<-EOS.undent


### PR DESCRIPTION
Busted and its dependencies are only required to run (unit/functional) tests.

cc @justinmk https://github.com/neovim/neovim/pull/2447#issuecomment-94101936