### PR TITLE
Compile neovim with verbose

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -62,6 +62,7 @@ class Neovim < Formula
            "CMAKE_BUILD_TYPE=RelWithDebInfo",
            "DEPS_CMAKE_FLAGS=-DUSE_BUNDLED_BUSTED=OFF",
            "CMAKE_EXTRA_FLAGS=\"-DCMAKE_INSTALL_PREFIX:PATH=#{prefix}\"",
+           "VERBOSE=1",
            "install"
   end
 


### PR DESCRIPTION
Homebrew will hidden the output unless passing `--verbose`.
At the same time, verbose output will be recorded into log file,
which it's good for debugging.