### PR TITLE
Fix missing `pkg-config` ´error due to dependencies order

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -2,11 +2,11 @@ class Neovim < Formula
   homepage "http://neovim.io"
   head "https://github.com/neovim/neovim.git"
 
+  depends_on "pkg-config" => :build
   depends_on "cmake" => :build
   depends_on "libtool" => :build
   depends_on "automake" => :build
   depends_on "autoconf" => :build
-  depends_on "pkg-config" => :build
   depends_on "gettext" => :build
   depends_on :python => :recommended if MacOS.version <= :snow_leopard
 


### PR DESCRIPTION
```
vagrant@ubuntu:~$ brew install --HEAD neovim
==> Installing neovim from neovim/homebrew-neovim
==> Installing dependencies for neovim/neovim/neovim: makedepend, openssl, pkg-config, curl, cmake, xz, libtool, autoconf, automake, gettext
==> Installing neovim/neovim/neovim dependency: makedepend
Error: /home/vagrant/.linuxbrew/opt/pkg-config not present or broken
Please reinstall pkg-config. Sorry :(
```
