### PR TITLE
Update install instructions.

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -71,7 +71,8 @@ class Neovim < Formula
       If you want support for Python plugins such as YouCompleteMe, you need
       to install a Python module in addition to Neovim itself.
 
-      See :h nvim-python-quickstart for more information.
+      Execute `:help nvim-python` in nvim or see
+      http://neovim.io/doc/user/nvim_python.html for more information.
     EOS
   end
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,29 @@
 homebrew-neovim
 ===============
-[![Build Status](https://travis-ci.org/neovim/homebrew-neovim.svg?branch=master)](https://travis-ci.org/neovim/homebrew-neovim)
+[![Build Status](https://travis-ci.org/neovim/homebrew-neovim.svg?branch=master)][travis](https://travis-ci.org/neovim/homebrew-neovim)
 
 Homebrew formula for neovim.
 
 ## Usage
 
-```bash
+```
 $ brew tap neovim/neovim
 $ brew install --HEAD neovim
 ```
 
+To **upgrade** from a previous version:
+
+```text
+$ brew update
+$ brew reinstall --HEAD neovim
+```
+
+For instructions on how to install the Python modules, see [`:help nvim-python`][nvim-python]
+
 ## Troubleshooting
 
-* Make sure you're using the right formula.  `brew info neovim` should have a
-  From line similar to this:
+* Make sure you're using the right formula. `brew info neovim` should have a
+  `From` line similar to this:
 
   ```text
   From: https://github.com/neovim/homebrew-neovim/blob/master/Formula/neovim.rb
@@ -24,11 +33,11 @@ $ brew install --HEAD neovim
   Do so with the following sequence of commands:
 
   ```text
-  brew uninstall neovim --force
-  brew prune
-  brew tap neovim/homebrew-neovim
-  brew tap --repair
-  brew install neovim --HEAD
+  $ brew uninstall neovim --force
+  $ brew prune
+  $ brew tap neovim/homebrew-neovim
+  $ brew tap --repair
+  $ brew install neovim --HEAD
   ```
 * Run `brew update` — then try again.
 * Run `brew doctor` — the doctor diagnoses common issues.
@@ -43,3 +52,4 @@ $ brew install --HEAD neovim
   neutralizing them.
 
 [clt-bug]: https://openradar.appspot.com/radar?id=6405426379751424
+[nvim-python]: http://neovim.io/doc/user/nvim_python.html


### PR DESCRIPTION
Add the additional instructions in the Neovim wiki to the README. The wiki can now simply link to the Homebrew repo and doesn't duplicate some of the instructions.