### PR TITLE
[RFC] Use CMake directly, update caveats message.

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -75,11 +75,21 @@ class Neovim < Formula
   end
 
   def caveats; <<-EOS.undent
+      The Neovim executable is called 'nvim'. To use your existing Vim
+      configuration:
+          ln -s ~/.vimrc ~/.nvimrc
+          ln -s ~/.vim ~/.nvim
+      See ':help nvim' for more information on Neovim.
+
+      When upgrading Neovim, check the following page for breaking changes:
+          https://github.com/neovim/neovim/wiki/Following-HEAD
+
       If you want support for Python plugins such as YouCompleteMe, you need
       to install a Python module in addition to Neovim itself.
 
-      Execute `:help nvim-python` in nvim or see
-      http://neovim.io/doc/user/nvim_python.html for more information.
+      Execute ':help nvim-python' in nvim or see the following page for more
+      information:
+          http://neovim.io/doc/user/nvim_python.html
     EOS
   end
 


### PR DESCRIPTION
Since this packaging code is under the `neovim` organization, it might be used as reference. It should therefore use CMake directly and not use on the top-level Makefile, which was originally only intended as convenience function for the Neovim developers.

Also updated the caveats message, using a text adapted from the Arch Linux post-install message.