### PR TITLE
[RFC] Formula: Reorder CMake flags.

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -67,10 +67,9 @@ class Neovim < Formula
 
     mkdir "build" do
       ohai "Building Neovim."
-      system "cmake", "..",
-             "-DDEPS_PREFIX=../deps-build/usr",
-             "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
-             *std_cmake_args
+      cmake_args = std_cmake_args + ["-DDEPS_PREFIX=../deps-build/usr",
+                                     "-DCMAKE_BUILD_TYPE=RelWithDebInfo"]
+      system "cmake", "..", *cmake_args
       system "make", "VERBOSE=1", "install"
     end
   end


### PR DESCRIPTION
CMAKE_BUILD_TYPE=RelWithDebInfo must come at the end to take effect,
as std_cmake_args contains CMAKE_BUILD_TYPE=Release.
Change the order while retaining Ruby 1.8 compatibility.

@soli Can you confirm that this still works?