### PR TITLE
minimal migration from neovim to vim

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -78,8 +78,9 @@ class Neovim < Formula
   def caveats; <<-EOS.undent
       The Neovim executable is called 'nvim'. To use your existing Vim
       configuration:
-          ln -s ~/.vimrc ~/.config/nvim/init.vim
-          ln -s ~/.vim ~/.config/nvim
+          mkdir -p ${XDG_CONFIG_HOME:=$HOME/.config}
+          ln -s ~/.vim $XDG_CONFIG_HOME/nvim
+          ln -s ~/.vimrc $XDG_CONFIG_HOME/nvim/init.vim
       See ':help nvim' for more information on Neovim.
 
       When upgrading Neovim, check the following page for breaking changes:


### PR DESCRIPTION
from commit https://github.com/neovim/neovim/commit/1ca5646bb52ec5c23b28f45bb7bc5d25cffad9b0, neovim dot-file becomes `$XDG_CONFIG_HOME/nvim/init.vim`, so the old migration commands doesn't work after this neovim commit. one should link the old `.vimrc` and .vim directory according to `:h nvim-from-vim`