### PR TITLE
switch the order of the config symlinks in formula

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -78,8 +78,8 @@ class Neovim < Formula
   def caveats; <<-EOS.undent
       The Neovim executable is called 'nvim'. To use your existing Vim
       configuration:
-          ln -s ~/.vimrc ~/.config/nvim/init.vim
           ln -s ~/.vim ~/.config/nvim
+          ln -s ~/.vimrc ~/.config/nvim/init.vim
       See ':help nvim' for more information on Neovim.
 
       When upgrading Neovim, check the following page for breaking changes:


### PR DESCRIPTION
As per [bergman](https://github.com/bergman)'s comment on [PR #102](https://github.com/neovim/homebrew-neovim/pull/102), I've switched the order of the symlinks in the formula to be more logical. 