### PR TITLE
Fix brew audit offense.

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -120,7 +120,7 @@ class Neovim < Formula
       ohai "Building Neovim."
       build_type = build.head? ? "Dev" : "RelWithDebInfo"
       cmake_args = std_cmake_args + ["-DDEPS_PREFIX=../deps-build/usr",
-                                     "-DCMAKE_BUILD_TYPE=#{build_type}",]
+                                     "-DCMAKE_BUILD_TYPE=#{build_type}"]
       system "cmake", "..", *cmake_args
       system "make", "VERBOSE=1", "install"
     end


### PR DESCRIPTION
```
== /usr/local/Library/Taps/neovim/homebrew-neovim/Formula/neovim.rb ==
C:123: 72: Avoid comma after the last item of an array, unless each item is on its own line.
1 file inspected, 1 offense detected
```

I'm pretty sure at some point (11f258c766bfeecf2c2d53fbd2f11727ce40d929) the audit asked for the trailing comma to be added, I don't think I would have changed it otherwise.. oh well.