### PR TITLE
fix build on travis equalsraf/neovim-qt#88

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -18,7 +18,7 @@ class Neovim < Formula
     end
 
     resource "luajit" do
-      url "http://luajit.org/download/LuaJIT-2.0.4.tar.gz"
+      url "https://github.com/neovim/deps/raw/master/opt/LuaJIT-2.0.4.tar.gz"
       sha256 "620fa4eb12375021bef6e4f237cbd2dd5d49e56beb414bee052c746beef1807d"
     end
 
@@ -63,7 +63,7 @@ class Neovim < Formula
     end
 
     resource "luajit" do
-      url "http://luajit.org/download/LuaJIT-2.0.4.tar.gz"
+      url "https://github.com/neovim/deps/raw/master/opt/LuaJIT-2.0.4.tar.gz"
       sha256 "620fa4eb12375021bef6e4f237cbd2dd5d49e56beb414bee052c746beef1807d"
     end
 


### PR DESCRIPTION
Travis cannot download LuaJIT from the official download location, see:

http://www.freelists.org/post/luajit/luajit-git-is-not-accessible-from-Travis-CI
https://github.com/moteus/lua-travis-example/issues/19

and

https://github.com/equalsraf/neovim-qt/pull/88

Change the the resource location for LuaJIT to the github mirror. The
resource has to be renamed because a resource caching bug in Homebrew
breaks the build otherwise. The staging directory is still set to
"luajit".

Formula is tested and works.