### PR TITLE
Fix FORTIFY_SOURCE flag to OS.mac only and Support Realese build

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -2,8 +2,6 @@ class Neovim < Formula
   desc "Ambitious Vim-fork focused on extensibility and agility"
   homepage "https://neovim.io"
 
-  option "with-release", "Compile in release mode"
-
   stable do
     url "https://github.com/neovim/neovim/archive/v0.1.2.tar.gz"
     sha256 "549881465eff82454660ae92d857d6ffa22383d45c94c46f3753fd1b0e699247"
@@ -95,6 +93,8 @@ class Neovim < Formula
     end
   end
 
+  option "with-release", "Compile in release mode"
+
   depends_on "cmake" => :build
   depends_on "libtool" => :build
   depends_on "automake" => :build
@@ -129,11 +129,11 @@ class Neovim < Formula
         end
       cmake_args = std_cmake_args + ["-DDEPS_PREFIX=../deps-build/usr",
                                      "-DCMAKE_BUILD_TYPE=#{build_type}"]
-      unless build.head?
-        cmake_args += ["-DCMAKE_C_FLAGS_RELWITHDEBINFO='-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1'"]
-      end
-
       if OS.mac?
+        unless build.head?
+          cmake_args += ["-DCMAKE_C_FLAGS_#{build_type.upcase}='-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1'"]
+        end
+
         cmake_args += ["-DIconv_INCLUDE_DIRS:PATH=/usr/include",
                        "-DIconv_LIBRARIES:PATH=/usr/lib/libiconv.dylib"]
       end


### PR DESCRIPTION
Fixed `if OS.mac` issue and support `Release` build. and

> Thanks. Cmakelist.txt should so this automatically... Why doesn't it?

Maybe Homebrew always automatically resets `CMAKE_C_FLAGS_***=-DNDEBUG`.
Caused by this?

```bash
==> Building Neovim.
==> cmake .. -DCMAKE_C_FLAGS_RELEASE=-DNDEBUG -DCMAKE_CXX_FLAGS_RELEASE=-DNDEBUG -DCMAKE_INSTALL_PREFIX=/usr/local/Cellar/neovim/0.1.2 -DCMAKE_BUILD_TYPE=Release -DCMAKE_FIND_FRAMEWORK=LAST -DCMAKE_VERBOSE_MAKEFILE=ON -Wno-dev -DDEPS_PREFIX=../deps-build/usr -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS_RELEASE='-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1' -DIconv_INCLUDE_DIRS:PATH=/usr/include -DIconv_LIBRARIES:PATH=/usr/lib/libiconv.dylib
```

NOTE:
`clang` began to display a warning from 10.10.4. Both of Homebrew and `ninja` build.
But I don't know the meaning of this warning. I hope this is useful for you.


```bash
In file included from /usr/include/errno.h:23:
/usr/include/sys/errno.h:235:9: warning: 'EILSEQ' macro redefined [-Wmacro-redefined]
#define EILSEQ          92              /* Illegal byte sequence */
        ^
/tmp/neovim20160406-84999-pc3hu9/neovim-0.1.2/src/nvim/iconv.h:38:12: note: previous definition is here
#   define EILSEQ 123
           ^
1 warning generated.
```