### PR TITLE
[RFC] Disable building Luv.

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -114,7 +114,8 @@ class Neovim < Formula
     cd "deps-build" do
       ohai "Building third-party dependencies."
       system "cmake", "../third-party", "-DUSE_BUNDLED_BUSTED=OFF",
-             "-DUSE_EXISTING_SRC_DIR=ON", *std_cmake_args
+             "-DUSE_BUNDLED_LUV=OFF", "-DUSE_EXISTING_SRC_DIR=ON",
+             *std_cmake_args
       system "make", "VERBOSE=1"
     end
 


### PR DESCRIPTION
Luv is only required for the Lua client (i.e. for running the tests), so
we can disable it.

Resolves #143.