### PR TITLE
Use libtermkey git repository when installing HEAD (refers #155)

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -83,8 +83,7 @@ class Neovim < Formula
     end
 
     resource "libtermkey" do
-      url "http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.18.tar.gz"
-      sha256 "239746de41c845af52bb3c14055558f743292dd6c24ac26c2d6567a5a6093926"
+      url "https://github.com/neovim/libtermkey.git"
     end
 
     resource "libvterm" do


### PR DESCRIPTION
This should prevent the problem when users try to install `libtermkey` dependency from behind a firewall. The libtermkey git repository doesn't provide tags/versions, so I preferred to adopt it only on the `HEAD` version (after all, people upgrades neovim frequently).
