### PR TITLE
Fix #175: Neovim depends on gperf

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -119,7 +119,8 @@ class Neovim < Formula
     cd "deps-build" do
       ohai "Building third-party dependencies."
       system "cmake", "../third-party", "-DUSE_BUNDLED_BUSTED=OFF",
-             "-DUSE_BUNDLED_LUV=OFF", "-DUSE_EXISTING_SRC_DIR=ON",
+             "-DUSE_BUNDLED_GPERF=OFF", "-DUSE_BUNDLED_LUV=OFF",
+             "-DUSE_EXISTING_SRC_DIR=ON",
              *std_cmake_args
       system "make", "VERBOSE=1"
     end


### PR DESCRIPTION
In HEAD, we now require gperf, but OS X already has it--at least since
Yosemite.  So let's turn off the building of gperf in the deps build.