### PR TITLE
Report correct version for --HEAD

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -49,7 +49,7 @@ class Neovim < Formula
   end
 
   head do
-    url "https://github.com/neovim/neovim.git"
+    url "https://github.com/neovim/neovim.git", :shallow => false
 
     # Third-party dependencies for latest repo revision.
     resource "libuv" do


### PR DESCRIPTION
Homebrew uses shallow clones by default. That means that the history consists
only of the latest commit and no tags.

git-describe was not amused.

Now we use a full clone instead.

Closes #135.