### PR TITLE
Remove addition of FORTIFY_SOURCE, which is not needed anymore

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -70,10 +70,6 @@ class Neovim < Formula
       cmake_args += ["-DENABLE_JEMALLOC=OFF"]
 
       if OS.mac?
-        unless build.head?
-          cmake_args += ["-DCMAKE_C_FLAGS_#{build_type.upcase}='-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1'"]
-        end
-
         cmake_args += ["-DIconv_INCLUDE_DIRS:PATH=/usr/include",
                        "-DIconv_LIBRARIES:PATH=/usr/lib/libiconv.dylib"]
       end


### PR DESCRIPTION
This part was introduced in #138 to fix v0.1.2 bug.
Even at that time, the bug is already fixed on head (this is why `unless build.head?`).

A long time has passed, and now there is no need to handling the bug anymore.

This PR also fix the problem that RelWithDebInfo's CFLAGS is ignored.