### PR TITLE
Use static library of jemalloc on macOS

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -13,6 +13,7 @@ class Neovim < Formula
   depends_on "automake" => :build
   depends_on "autoconf" => :build
   depends_on "pkg-config" => :build
+  depends_on "jemalloc" => :recommended
   depends_on "libuv"
   depends_on "msgpack"
   depends_on "unibilium"
@@ -66,11 +67,10 @@ class Neovim < Formula
       cmake_args = std_cmake_args + ["-DDEPS_PREFIX=../deps-build/usr",
                                      "-DCMAKE_BUILD_TYPE=#{build_type}"]
 
-      # Disable jemalloc, see https://github.com/neovim/neovim/issues/5681
-      # cmake_args += ["-DENABLE_JEMALLOC=OFF"] if build.without?("jemalloc")
-      cmake_args += ["-DENABLE_JEMALLOC=OFF"]
+      cmake_args += ["-DENABLE_JEMALLOC=OFF"] if build.without?("jemalloc")
 
       if OS.mac?
+        cmake_args += ["-DJEMALLOC_LIBRARY=#{Formula["jemalloc"].opt_lib}/libjemalloc.a"] if build.with?("jemalloc")
         cmake_args += ["-DIconv_INCLUDE_DIRS:PATH=/usr/include",
                        "-DIconv_LIBRARIES:PATH=/usr/lib/libiconv.dylib"]
       end


### PR DESCRIPTION
A Workaround for neovim/neovim#5681, until #201 is fixed.