### PR TITLE
Re-parallelize build

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -39,7 +39,6 @@ class Neovim < Formula
   end
 
   def install
-    ENV.deparallelize
     ENV["HOME"] = buildpath
 
     resources.each do |r|


### PR DESCRIPTION
`ENV.deparallelize` was added in a0e6cb8, with no reason.
Since neovim upstream make use of parallel already and parallel build has no problem, I think we can remove this and take advantage of parallel build.