### PR TITLE
Explicitly use msgpack from homebrew

### DIFF
--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -71,6 +71,7 @@ class Neovim < Formula
 
       if OS.mac?
         cmake_args += ["-DJEMALLOC_LIBRARY=#{Formula["jemalloc"].opt_lib}/libjemalloc.a"] if build.with?("jemalloc")
+        cmake_args += ["-DMSGPACK_LIBRARY=#{Formula["msgpack"].opt_lib}/libmsgpackc.2.dylib"]
         cmake_args += ["-DIconv_INCLUDE_DIRS:PATH=/usr/include",
                        "-DIconv_LIBRARIES:PATH=/usr/lib/libiconv.dylib"]
       end


### PR DESCRIPTION
When homebrew is installed in a non-default path (e.g. under `~`)
this formula wasn't able to find the msgpack dylib.

This change explicitly configures the build to use the msgpack dylib
from the path in which homebrew installed it.

This should fix errors encountered at install like
`error on install: dyld: Library not loaded: @rpath/libmsgpackc.2.dylib`